### PR TITLE
Fix device search parameter

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -47,8 +47,7 @@ export const deviceService = {
 
   // 기기 검색
   async search(query: string) {
-    const url =
-      `${API_URL}/api/v1/user/devices/search?query=${encodeURIComponent(query)}`
+    const url = `${API_URL}/api/v1/user/devices/search?q=${encodeURIComponent(query)}`
     const response = await fetch(url, {
       headers: getAuthHeaders(),
     })


### PR DESCRIPTION
## Summary
- update device search API call to use `q` parameter

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685c141beb0c83319b4bd0cf1e2adcb4